### PR TITLE
Application Name support in connection string

### DIFF
--- a/Invoke-SqlCmd2/Public/Invoke-SqlCmd2.ps1
+++ b/Invoke-SqlCmd2/Public/Invoke-SqlCmd2.ps1
@@ -59,6 +59,9 @@ function Invoke-Sqlcmd2
         If specified, use an existing SQLConnection.
             We attempt to open this connection if it is closed
 
+    .PARAMETER ApplicationName
+    	If specified, adds the given string into the ConnectionString's Application Name property which is visible via SQL Server monitoring scripts/utilities to indicate where the query originated.
+
     .INPUTS
         None
             You cannot pipe objects to Invoke-Sqlcmd2
@@ -137,7 +140,7 @@ function Invoke-Sqlcmd2
 
     .NOTES
         Changelog moved to CHANGELOG.md:
-        
+
         https://github.com/sqlcollaborative/Invoke-SqlCmd2/blob/master/CHANGELOG.md
 
     .LINK
@@ -410,7 +413,7 @@ function Invoke-Sqlcmd2
                 $CSBuilder["Server"] = $SQLInstance
                 $CSBuilder["Database"] = $Database
                 $CSBuilder["Connection Timeout"] = $ConnectionTimeout
-                
+
                 if ($Encrypt) {
                     $CSBuilder["Encrypt"] = $true
                 }
@@ -432,7 +435,7 @@ function Invoke-Sqlcmd2
                 }
                 $conn = New-Object -TypeName System.Data.SqlClient.SQLConnection
 
-                $ConnectionString = $CSBuilder.ToString();
+                $ConnectionString = $CSBuilder.ToString()
                 $conn.ConnectionString = $ConnectionString
                 Write-Debug "ConnectionString $ConnectionString"
 

--- a/Invoke-SqlCmd2/Public/Invoke-SqlCmd2.ps1
+++ b/Invoke-SqlCmd2/Public/Invoke-SqlCmd2.ps1
@@ -407,31 +407,31 @@ function Invoke-Sqlcmd2
             else
             {
 
-                $CSBuilder = New-Object -TypeName System.Data.SqlClient.SqlConnectionStringBuilder;
-                $CSBuilder["Server"] = $SQLInstance;
-                $CSBuilder["Database"] = $Database;
-                $CSBuilder["Connection Timeout"] = $ConnectionTimeout;
+                $CSBuilder = New-Object -TypeName System.Data.SqlClient.SqlConnectionStringBuilder
+                $CSBuilder["Server"] = $SQLInstance
+                $CSBuilder["Database"] = $Database
+                $CSBuilder["Connection Timeout"] = $ConnectionTimeout
                 
                 if ($Encrypt) {
-                    $CSBuilder["Encrypt"] = $true;
+                    $CSBuilder["Encrypt"] = $true
                 }
 
                 if ($Credential) {
-                    $CSBuilder["Trusted_Connection"] = $false;
+                    $CSBuilder["Trusted_Connection"] = $false
                     $CSBuilder["User ID"] = $Credential.UserName
                     $CSBuilder["Password"] = $Credential.GetNetworkCredential().Password
                 } else {
-                    $CSBuilder["Integrated Security"] = $true;
+                    $CSBuilder["Integrated Security"] = $true
                 }
                 if ($ApplicationName) {
-                    $CSBuilder["Application Name"] = $ApplicationName;
+                    $CSBuilder["Application Name"] = $ApplicationName
                 } else {
-                    $ScriptName = (Get-PSCallStack)[-1].Command.ToString();
+                    $ScriptName = (Get-PSCallStack)[-1].Command.ToString()
                     if ($ScriptName -ne "<ScriptBlock>") {
-                        $CSBuilder["Application Name"] = (Get-PSCallStack)[-1].Command.ToString();
+                        $CSBuilder["Application Name"] = $ScriptName
                     }
                 }
-                $conn = New-Object System.Data.SqlClient.SQLConnection;
+                $conn = New-Object System.Data.SqlClient.SQLConnection
 
                 $ConnectionString = $CSBuilder.ToString();
                 $conn.ConnectionString = $ConnectionString

--- a/Invoke-SqlCmd2/Public/Invoke-SqlCmd2.ps1
+++ b/Invoke-SqlCmd2/Public/Invoke-SqlCmd2.ps1
@@ -406,7 +406,6 @@ function Invoke-Sqlcmd2
             }
             else
             {
-
                 $CSBuilder = New-Object -TypeName System.Data.SqlClient.SqlConnectionStringBuilder
                 $CSBuilder["Server"] = $SQLInstance
                 $CSBuilder["Database"] = $Database
@@ -431,7 +430,7 @@ function Invoke-Sqlcmd2
                         $CSBuilder["Application Name"] = $ScriptName
                     }
                 }
-                $conn = New-Object System.Data.SqlClient.SQLConnection
+                $conn = New-Object -TypeName System.Data.SqlClient.SQLConnection
 
                 $ConnectionString = $CSBuilder.ToString();
                 $conn.ConnectionString = $ConnectionString


### PR DESCRIPTION
These changes add support for a new optional parameter, `ApplicationName`. If specified, this parameter's value will be added to the `ConnectionString`'s `Application Name` parameter. If not supplied, an attempt to determine the parent script's filename is made.

I've also changed the creation of the `ConnectionString` from basic string formatting to using the SqlConnectionStringBuilder class to reduce redundant code and make adding parameters into the `ConnectionString` on a conditional basis cleaner.