### PR TITLE
guard clauses to make $ds.Tables[0] safe if result contains no values

### DIFF
--- a/Invoke-SqlCmd2/Public/Invoke-SqlCmd2.ps1
+++ b/Invoke-SqlCmd2/Public/Invoke-SqlCmd2.ps1
@@ -430,7 +430,7 @@ function Invoke-Sqlcmd2 {
 			}
 
 			#Following EventHandler is used for PRINT and RAISERROR T-SQL statements. Executed when -Verbose parameter specified by caller
-			if ($PSBoundParameters.Verbose) {
+            if ($PSBoundParameters.Verbose) {
 				$conn.FireInfoMessageEventOnUserErrors = $false # Shiyang, $true will change the SQL exception to information
 				$handler = [System.Data.SqlClient.SqlInfoMessageEventHandler] { Write-Verbose "$($_)" }
 				$conn.add_InfoMessage($handler)
@@ -512,16 +512,19 @@ function Invoke-Sqlcmd2 {
 				#Close the connection
 				if (-not $PSBoundParameters.ContainsKey('SQLConnection')) {
 					$conn.Close()
-				}               
+				}
 			}
 
 			if ($AppendServerInstance) {
 				#Basics from Chad Miller
 				$Column = New-Object Data.DataColumn
 				$Column.ColumnName = "ServerInstance"
-				$ds.Tables[0].Columns.Add($Column)
-				Foreach ($row in $ds.Tables[0]) {
-					$row.ServerInstance = $SQLInstance
+
+				if($ds.Tables.Count -ne 0) {
+					$ds.Tables[0].Columns.Add($Column)
+					Foreach ($row in $ds.Tables[0]) {
+						$row.ServerInstance = $SQLInstance
+					}
 				}
 			}
 
@@ -533,17 +536,24 @@ function Invoke-Sqlcmd2 {
 					$ds.Tables
 				}
 				'DataRow' {
-					$ds.Tables[0]
+					if($ds.Tables.Count -ne 0) {
+						$ds.Tables[0]
+					}
 				}
 				'PSObject' {
-					#Scrub DBNulls - Provides convenient results you can use comparisons with
-					#Introduces overhead (e.g. ~2000 rows w/ ~80 columns went from .15 Seconds to .65 Seconds - depending on your data could be much more!)
-					foreach ($row in $ds.Tables[0].Rows) {
-						[DBNullScrubber]::DataRowToPSObject($row)
+					if($ds.Tables.Count -ne 0) {
+						#Scrub DBNulls - Provides convenient results you can use comparisons with
+						#Introduces overhead (e.g. ~2000 rows w/ ~80 columns went from .15 Seconds to .65 Seconds - depending on your data could be much more!)
+						foreach ($row in $ds.Tables[0].Rows) {
+
+							[DBNullScrubber]::DataRowToPSObject($row)
+						}
 					}
 				}
 				'SingleValue' {
-					$ds.Tables[0] | Select-Object -ExpandProperty $ds.Tables[0].Columns[0].ColumnName
+					if($ds.Tables.Count -ne 0) {
+						$ds.Tables[0] | Select-Object -ExpandProperty $ds.Tables[0].Columns[0].ColumnName
+					}
 				}
 			}
 		}

--- a/Invoke-SqlCmd2/Public/Invoke-SqlCmd2.ps1
+++ b/Invoke-SqlCmd2/Public/Invoke-SqlCmd2.ps1
@@ -430,7 +430,7 @@ function Invoke-Sqlcmd2 {
 			}
 
 			#Following EventHandler is used for PRINT and RAISERROR T-SQL statements. Executed when -Verbose parameter specified by caller
-            if ($PSBoundParameters.Verbose) {
+			if ($PSBoundParameters.Verbose) {
 				$conn.FireInfoMessageEventOnUserErrors = $false # Shiyang, $true will change the SQL exception to information
 				$handler = [System.Data.SqlClient.SqlInfoMessageEventHandler] { Write-Verbose "$($_)" }
 				$conn.add_InfoMessage($handler)
@@ -459,7 +459,7 @@ function Invoke-Sqlcmd2 {
 			}
 			catch [System.Data.SqlClient.SqlException] {
 				# For SQL exception
-            
+
 				$Err = $_
 
 				Write-Verbose "Capture SQL Error"


### PR DESCRIPTION
might only be an issue when running Set-StrictMode -Version 3 or higher.