### PR TITLE
Added guard clauses for Set-StrictMode -Version Latest

### DIFF
--- a/Invoke-SqlCmd2/Public/Invoke-SqlCmd2.ps1
+++ b/Invoke-SqlCmd2/Public/Invoke-SqlCmd2.ps1
@@ -383,7 +383,7 @@ function Invoke-Sqlcmd2 {
 				else {
 					$CSBuilder["Integrated Security"] = $true
 				}
-				if ($ApplicationName) {
+				if ((Test-Path variable:ApplicationName) -and $ApplicationName) {
 					$CSBuilder["Application Name"] = $ApplicationName
 				}
 				else {
@@ -408,7 +408,7 @@ function Invoke-Sqlcmd2 {
 			}
 			
 			#Following EventHandler is used for PRINT and RAISERROR T-SQL statements. Executed when -Verbose parameter specified by caller
-			if ($PSBoundParameters.Verbose) {
+			if ($PSBoundParameters.ContainsKey('Verbose') -and $PSBoundParameters.Verbose) {
 				$conn.FireInfoMessageEventOnUserErrors = $false # Shiyang, $true will change the SQL exception to information
 				$handler = [System.Data.SqlClient.SqlInfoMessageEventHandler] { Write-Verbose "$($_)" }
 				$conn.add_InfoMessage($handler)
@@ -442,7 +442,7 @@ function Invoke-Sqlcmd2 {
 				
 				Write-Verbose "Capture SQL Error"
 				
-				if ($PSBoundParameters.Verbose) {
+				if ($PSBoundParameters.ContainsKey('Verbose') -and $PSBoundParameters.Verbose) {
 					Write-Verbose "SQL Error:  $Err"
 				} #Shiyang, add the verbose output of exception
 				
@@ -467,7 +467,7 @@ function Invoke-Sqlcmd2 {
 				
 				$Err = $_
 				
-				if ($PSBoundParameters.Verbose) {
+				if ($PSBoundParameters.ContainsKey('Verbose') -and $PSBoundParameters.Verbose) {
 					Write-Verbose "Other Error:  $Err"
 				}
 				


### PR DESCRIPTION
Added guard clauses for $ApplicationName and $PSBoundParameters.Verbose, so missing values don't cause problems when running with Set-StrictMode -Version Latest.

Without them I get these error messages:
The variable '$ApplicationName' cannot be retrieved because it has not been set.
    at Invoke-Sqlcmd2.ps1: line 386
The property 'Verbose' cannot be found on this object. Verify that the property exists.
    at Invoke-Sqlcmd2.ps1: line 467

To be honest my preference would be for $ApplicationName to be passed in as an optional parameter, but I don't know what the original Invoke-SqlCmd does here.