### PR TITLE
Changed Resolve-Path and Test-Path to use LiteralPath vs Path.  

### DIFF
--- a/Invoke-SqlCmd2/Public/Invoke-SqlCmd2.ps1
+++ b/Invoke-SqlCmd2/Public/Invoke-SqlCmd2.ps1
@@ -206,7 +206,7 @@ function Invoke-Sqlcmd2 {
 				   Mandatory = $true,
 				   ValueFromPipelineByPropertyName = $true,
 				   ValueFromRemainingArguments = $false)]
-		[ValidateScript({ Test-Path $_ })]
+		[ValidateScript({ Test-Path -LiteralPath $_ })]
 		[string]$InputFile,
 		[Parameter(ParameterSetName = 'Ins-Que',
 				   Position = 3,
@@ -278,7 +278,7 @@ function Invoke-Sqlcmd2 {
 	
 	begin {
 		if ($InputFile) {
-			$filePath = $(Resolve-Path $InputFile).ProviderPath
+			$filePath = $(Resolve-Path -LiteralPath $InputFile).ProviderPath
 			$Query = [System.IO.File]::ReadAllText("$filePath")
 		}
 		


### PR DESCRIPTION
Path contains wild card expressions that can lead to problems.

LiteralPath allows for legal files names like anything[here].sql

see https://technet.microsoft.com/en-us/library/ff730956.aspx