### PR TITLE
Fix to allow -As PSObject to work with PSCore

### DIFF
--- a/Invoke-SqlCmd2/Public/Invoke-SqlCmd2.ps1
+++ b/Invoke-SqlCmd2/Public/Invoke-SqlCmd2.ps1
@@ -335,7 +335,13 @@ function Invoke-Sqlcmd2 {
 '@
 
             try {
-                Add-Type -TypeDefinition $cSharp -ReferencedAssemblies 'System.Data', 'System.Xml' -ErrorAction stop
+                if ($PSEdition -ne 'Core'){
+                    Add-Type -TypeDefinition $cSharp -ReferencedAssemblies 'System.Data', 'System.Xml' -ErrorAction stop
+                } else {
+                    Add-Type $cSharp -ErrorAction stop
+                }
+
+                
             }
             catch {
                 if (-not $_.ToString() -like "*The type name 'DBNullScrubber' already exists*") {


### PR DESCRIPTION
This update allows -as PSObject to work in PScore. There was an error that the object type were missing. I used the code from the following PowerShell [issue](https://github.com/PowerShell/PowerShell/issues/7092) as an example to fix it. I tested this in PowerShell 5.1 and 6.04 on both Windows and Ubuntu. Let me know if you have any questions! 